### PR TITLE
유저 계정 관련 API 구현

### DIFF
--- a/src/main/java/org/example/yulion/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/yulion/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package org.example.yulion.domain.auth.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Auth")
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @RestController
 @RequestMapping("/api/v1/auth")

--- a/src/main/java/org/example/yulion/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/org/example/yulion/domain/auth/dto/request/SignupRequest.java
@@ -28,9 +28,6 @@ public record SignupRequest(
 
         LocalDate birth,
 
-        @NotBlank(message = "프로필 이미지 URL은 공백이 아니어야 합니다")
-        String profileImageUrl,
-
         @NotNull(message = "학번은 null이 아니어야 합니다")
         Long studentId,
         String githubUsername

--- a/src/main/java/org/example/yulion/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/org/example/yulion/domain/auth/dto/request/SignupRequest.java
@@ -1,15 +1,9 @@
 package org.example.yulion.domain.auth.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import org.example.yulion.global.auth.AuthConstants;
 
 import java.time.LocalDate;
-
 
 public record SignupRequest(
 
@@ -29,8 +23,16 @@ public record SignupRequest(
         @Size(min = 6, message = "비밀번호의 길이는 최소 6자 입니다")
         String password,
 
+        @NotBlank(message = "성별은 공백이 아니어야 합니다")
         String gender,
 
-        LocalDate birth
+        LocalDate birth,
+
+        @NotBlank(message = "프로필 이미지 URL은 공백이 아니어야 합니다")
+        String profileImageUrl,
+
+        @NotNull(message = "학번은 null이 아니어야 합니다")
+        Long studentId,
+        String githubUsername
 ) {
 }

--- a/src/main/java/org/example/yulion/domain/auth/dto/response/SignupResult.java
+++ b/src/main/java/org/example/yulion/domain/auth/dto/response/SignupResult.java
@@ -1,6 +1,11 @@
 package org.example.yulion.domain.auth.dto.response;
 
+import org.example.yulion.domain.user.domain.User;
+
 public record SignupResult(
-    // TODO 회원가입 완료시 프론트에서 필요한 값
+        long userId
 ) {
+    public static SignupResult of(User user) {
+        return new SignupResult(user.getId());
+    }
 }

--- a/src/main/java/org/example/yulion/domain/auth/service/AuthSignupService.java
+++ b/src/main/java/org/example/yulion/domain/auth/service/AuthSignupService.java
@@ -29,7 +29,6 @@ public class AuthSignupService {
                 .phoneNumber(signupRequest.phoneNumber())
                 .gender(signupRequest.gender())
                 .birth(signupRequest.birth())
-                .profileImageUrl(signupRequest.profileImageUrl())
                 .studentId(signupRequest.studentId())
                 .githubUsername(signupRequest.githubUsername())
                 .build();

--- a/src/main/java/org/example/yulion/domain/auth/service/AuthSignupService.java
+++ b/src/main/java/org/example/yulion/domain/auth/service/AuthSignupService.java
@@ -29,12 +29,15 @@ public class AuthSignupService {
                 .phoneNumber(signupRequest.phoneNumber())
                 .gender(signupRequest.gender())
                 .birth(signupRequest.birth())
+                .profileImageUrl(signupRequest.profileImageUrl())
+                .studentId(signupRequest.studentId())
+                .githubUsername(signupRequest.githubUsername())
                 .build();
         userRepository.save(user);
 
         log.info("회원가입 완료: ID: {}, 이메일: {}, 닉네임: {}", user.getId(), user.getEmail(), user.getNickname());
 
-        return new SignupResult();
+        return SignupResult.of(user);
     }
 
 

--- a/src/main/java/org/example/yulion/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/yulion/domain/user/controller/UserController.java
@@ -1,0 +1,38 @@
+package org.example.yulion.domain.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.example.yulion.domain.user.dto.request.UserProfileUpdateRequest;
+import org.example.yulion.domain.user.dto.response.MyProfileResponse;
+import org.example.yulion.domain.user.service.UserProfileService;
+import org.example.yulion.global.auth.userdetails.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "User")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final UserProfileService userProfileService;
+
+
+    @Operation(summary = "자신의 프로필 조회")
+    @GetMapping("/me/profiles")
+    public ResponseEntity<MyProfileResponse> getMyProfile(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(userProfileService.getMyProfile(userDetails.getId()));
+    }
+
+    @Operation(summary = "자신의 프로필 수정")
+    @PutMapping("/me/profiles")
+    public ResponseEntity<MyProfileResponse> updateMyProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UserProfileUpdateRequest updateRequest) {
+        return ResponseEntity.ok(userProfileService.updateProfile(userDetails.getId(), updateRequest));
+    }
+
+
+}

--- a/src/main/java/org/example/yulion/domain/user/controller/UserStatusController.java
+++ b/src/main/java/org/example/yulion/domain/user/controller/UserStatusController.java
@@ -1,0 +1,36 @@
+package org.example.yulion.domain.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.example.yulion.domain.user.service.UserStatusService;
+import org.example.yulion.global.auth.userdetails.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "User")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/users/status")
+public class UserStatusController {
+
+    private final UserStatusService userStatusService;
+
+    @Operation(summary = "계정 활성화")
+    @Secured("ROLE_ADMIN")
+    @PostMapping
+    public ResponseEntity<Void> activateUser(@RequestParam("user_id") Long userId) {
+        userStatusService.activateUser(userId);
+        return ResponseEntity.noContent().build();
+    }
+
+
+    @Operation(summary = "자신의 계정 탈퇴")
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        userStatusService.withdrawUser(userDetails.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/example/yulion/domain/user/domain/User.java
+++ b/src/main/java/org/example/yulion/domain/user/domain/User.java
@@ -3,8 +3,12 @@ package org.example.yulion.domain.user.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.example.yulion.domain.common.BaseTimeEntity;
+import org.example.yulion.domain.user.dto.request.UserProfileUpdateRequest;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static java.util.Objects.requireNonNullElse;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -17,7 +21,7 @@ public class User extends BaseTimeEntity {
 
     private String password;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true, nullable = false, length = 15)
     private String phoneNumber;
 
     @Column(nullable = false)
@@ -35,8 +39,20 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private UserStatus status;
 
+    @Column(unique = true, nullable = false)
+    private Long studentId;
+
+    @Column(unique = true)
+    private String githubUsername;
+
+    @Column(nullable = false)
+    private String profileImageUrl;
+
+    private LocalDateTime deletedAt;
+
     @Builder
-    protected User(String password, String phoneNumber, String nickname, String email, UserRole role, String gender, LocalDate birth) {
+    protected User(String password, String phoneNumber, String nickname, String email, UserRole role, String gender,
+                   LocalDate birth, Long studentId, String githubUsername, String profileImageUrl) {
         this.password = password;
         this.phoneNumber = phoneNumber;
         this.email = email;
@@ -44,7 +60,26 @@ public class User extends BaseTimeEntity {
         this.role = role;
         this.gender = gender;
         this.birth = birth;
+        this.studentId = studentId;
+        this.githubUsername = githubUsername;
+        this.profileImageUrl = profileImageUrl;
         this.status = UserStatus.WAITING;
+    }
+
+    public void updateProfile(UserProfileUpdateRequest updateRequest) {
+        this.nickname = requireNonNullElse(updateRequest.nickname(), this.nickname);
+        this.birth = requireNonNullElse(updateRequest.birth(), this.birth);
+        this.githubUsername = requireNonNullElse(updateRequest.githubUsername(), this.githubUsername);
+        this.profileImageUrl = requireNonNullElse(updateRequest.profileImageUrl(), this.profileImageUrl);
+    }
+
+    public void activate() {
+        this.status = UserStatus.ACTIVE;
+    }
+
+    public void withdraw() {
+        this.status = UserStatus.SUSPENDED;
+        this.deletedAt = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/org/example/yulion/domain/user/domain/User.java
+++ b/src/main/java/org/example/yulion/domain/user/domain/User.java
@@ -45,7 +45,6 @@ public class User extends BaseTimeEntity {
     @Column(unique = true)
     private String githubUsername;
 
-    @Column(nullable = false)
     private String profileImageUrl;
 
     private LocalDateTime deletedAt;

--- a/src/main/java/org/example/yulion/domain/user/dto/request/UserProfileUpdateRequest.java
+++ b/src/main/java/org/example/yulion/domain/user/dto/request/UserProfileUpdateRequest.java
@@ -1,0 +1,21 @@
+package org.example.yulion.domain.user.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+import static org.example.yulion.global.utils.ProjectTimeFormat.LOCAL_DATE_PATTERN;
+import static org.example.yulion.global.utils.ProjectTimeFormat.LOCAL_DATE_PATTERN_EXAMPLE;
+
+
+@Schema(description = "사용자 프로필 수정 요청")
+public record UserProfileUpdateRequest(
+        String nickname,
+        @Schema(description = "생년월일", example = LOCAL_DATE_PATTERN_EXAMPLE)
+        @JsonFormat(pattern = LOCAL_DATE_PATTERN)
+        LocalDate birth,
+        String profileImageUrl,
+        String githubUsername
+) {
+}

--- a/src/main/java/org/example/yulion/domain/user/dto/response/MyProfileResponse.java
+++ b/src/main/java/org/example/yulion/domain/user/dto/response/MyProfileResponse.java
@@ -1,0 +1,28 @@
+package org.example.yulion.domain.user.dto.response;
+
+import org.example.yulion.domain.user.domain.User;
+
+import java.time.LocalDate;
+
+public record MyProfileResponse(
+        long id,
+        String phoneNumber,
+        String nickname,
+        String email,
+        LocalDate birth,
+        String profileImageUrl,
+        String githubUsername
+) {
+    public static MyProfileResponse of(User user) {
+        return new MyProfileResponse(
+                user.getId(),
+                user.getPhoneNumber(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getBirth(),
+                user.getProfileImageUrl(),
+                user.getGithubUsername()
+        );
+    }
+
+}

--- a/src/main/java/org/example/yulion/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/yulion/domain/user/repository/UserRepository.java
@@ -13,4 +13,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
+    default User findOrThrow(Long userId) {
+        return findById(userId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+    }
+
 }

--- a/src/main/java/org/example/yulion/domain/user/service/UserProfileService.java
+++ b/src/main/java/org/example/yulion/domain/user/service/UserProfileService.java
@@ -1,0 +1,29 @@
+package org.example.yulion.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.yulion.domain.user.domain.User;
+import org.example.yulion.domain.user.dto.request.UserProfileUpdateRequest;
+import org.example.yulion.domain.user.dto.response.MyProfileResponse;
+import org.example.yulion.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class UserProfileService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public MyProfileResponse getMyProfile(Long userId) {
+        return MyProfileResponse.of(userRepository.findOrThrow(userId));
+    }
+
+    @Transactional
+    public MyProfileResponse updateProfile(Long userId, UserProfileUpdateRequest updateRequest) {
+        User user = userRepository.findOrThrow(userId);
+        user.updateProfile(updateRequest);
+        return MyProfileResponse.of(user);
+    }
+
+}

--- a/src/main/java/org/example/yulion/domain/user/service/UserStatusService.java
+++ b/src/main/java/org/example/yulion/domain/user/service/UserStatusService.java
@@ -1,0 +1,26 @@
+package org.example.yulion.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.yulion.domain.user.domain.User;
+import org.example.yulion.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class UserStatusService {
+
+    private final UserRepository userRepository;
+
+    public void activateUser(final Long userId) {
+        User user = userRepository.findOrThrow(userId);
+        user.activate();
+    }
+
+    public void withdrawUser(final Long userId) {
+        User user = userRepository.findOrThrow(userId);
+        user.withdraw();
+    }
+
+}

--- a/src/main/java/org/example/yulion/global/config/security/SecurityAuthConfig.java
+++ b/src/main/java/org/example/yulion/global/config/security/SecurityAuthConfig.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.example.yulion.global.auth.userdetails.UserDetailsServiceImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -34,6 +36,13 @@ public class SecurityAuthConfig {
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
         return authConfig.getAuthenticationManager();
+    }
+
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
+        roleHierarchy.setHierarchy("ROLE_ADMIN > ROLE_OPERATOR ROLE_OPERATOR > ROLE_USER");
+        return roleHierarchy;
     }
 
 }

--- a/src/main/java/org/example/yulion/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/example/yulion/global/config/security/SecurityConfig.java
@@ -22,7 +22,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.List;
 import java.util.stream.Stream;
 
-@EnableMethodSecurity
+@EnableMethodSecurity(securedEnabled = true)
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Configuration
 public class SecurityConfig {

--- a/src/main/java/org/example/yulion/global/utils/ProjectTimeFormat.java
+++ b/src/main/java/org/example/yulion/global/utils/ProjectTimeFormat.java
@@ -1,0 +1,19 @@
+package org.example.yulion.global.utils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.ZoneId;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProjectTimeFormat {
+
+    public static final String LOCAL_DATE_PATTERN = "yyyy-MM-dd";
+    public static final String LOCAL_DATE_PATTERN_EXAMPLE = "2020-01-11";
+    public static final String LOCAL_DATE_TIME_PATTERN = "yyyy-MM-dd HH:mm:ss";
+    public static final String LOCAL_DATE_TIME_PATTERN_EXAMPLE = "2024-11-01 01:23:34";
+
+    public static final String SERVER_TIMEZONE = "Asia/Seoul";
+    public static final ZoneId SERVER_ZONE_ID = ZoneId.of(SERVER_TIMEZONE);
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,3 +27,4 @@ app:
     refresh:
       expiration: ${JWT_EXPIRATION_REFRESH}
   allow-origins: http://localhost:3000
+  backend-api: ${BACKEND_API}


### PR DESCRIPTION
## 이슈 연결

- close #4 

## 구현한 API

- GET [/api/v1/users/me/profiles] 자신의 프로필 조회
- PUT [/api/v1/users/me/profiles 자신의 프로필 수정
- POST [/api/v1/users/status] 계정 활성화
- DELETE [/api/v1/users/status/withdraw] 자신의 계정 탈퇴

## 작업 사항

- 유저 계정 관련 API 구현
- 회원가입시 필요한 정보 받도록 수정

