### PR TITLE
게시물 관련 API 구현

### DIFF
--- a/src/main/java/org/example/yulion/domain/category/domain/Category.java
+++ b/src/main/java/org/example/yulion/domain/category/domain/Category.java
@@ -1,0 +1,26 @@
+package org.example.yulion.domain.category.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Builder
+    protected Category(String name){
+        this.name = name;
+    }
+
+}

--- a/src/main/java/org/example/yulion/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/org/example/yulion/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,12 @@
+package org.example.yulion.domain.category.repository;
+
+import org.example.yulion.domain.category.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long>{
+    Optional<Category> findByName(String name);
+}

--- a/src/main/java/org/example/yulion/domain/part/domain/Part.java
+++ b/src/main/java/org/example/yulion/domain/part/domain/Part.java
@@ -1,0 +1,25 @@
+package org.example.yulion.domain.part.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Part {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Builder
+    protected Part(String name){
+        this.name = name;
+    }
+}

--- a/src/main/java/org/example/yulion/domain/part/repository/PartRepository.java
+++ b/src/main/java/org/example/yulion/domain/part/repository/PartRepository.java
@@ -1,0 +1,12 @@
+package org.example.yulion.domain.part.repository;
+
+import org.example.yulion.domain.part.domain.Part;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PartRepository extends JpaRepository<Part, Long>{
+    Optional<Part> findByName(String name);
+}

--- a/src/main/java/org/example/yulion/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/yulion/domain/post/controller/PostController.java
@@ -42,7 +42,6 @@ public class PostController {
     // 1. 게시글 생성
     @PostMapping("")
     public ResponseEntity<PostDetailResponse> createPost(@RequestBody PostCreateRequest request) {
-        log.info(request.toString());
         PostDetailResponse response = postService.addPost(request);
 
         return ResponseEntity.ok(response);

--- a/src/main/java/org/example/yulion/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/yulion/domain/post/controller/PostController.java
@@ -1,8 +1,9 @@
 package org.example.yulion.domain.post.controller;
 
-import org.example.yulion.domain.post.domain.Post;
+import lombok.extern.slf4j.Slf4j;
 import org.example.yulion.domain.post.dto.request.PostCreateRequest;
 import org.example.yulion.domain.post.dto.response.PostCommonListResponse;
+import org.example.yulion.domain.post.dto.response.PostCommonSummaryResponse;
 import org.example.yulion.domain.post.dto.response.PostDetailResponse;
 import org.example.yulion.domain.post.service.PostService;
 import org.springframework.data.domain.PageRequest;
@@ -11,6 +12,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RequestMapping("/api/v1/posts")
 @RestController
 public class PostController {
@@ -21,13 +23,14 @@ public class PostController {
      3. 게시글 수정
      4. 게시글 삭제
      5. 게시글 목록 조회
-         5-1. id + 파트 + 제목 + 작성자 + 작성일 + 조회수 (스터디 제외 전부)
-         5-2. id + 파트 + 제목 + 팀원 (스터디)
+         5-1. id + 파트 + 제목 + 작성자 + 작성일 + 조회수 (Notice, 커뮤니티)
+         5-2. id + 파트 + 제목 +  팀원 (스터디, 팀빌딩, Homework)
 
      6. 게시글 요약 목록 조회 (세가지)
-         6-1. 제목 + 날짜 (아래 제외 전부)
-         6-2. 제목 + 작성자(멘토) (스터디)
+         6-1. 제목 + 날짜 (Notice, 커뮤니티, Q&A, Homework))
+         6-2. 제목 + 멘토 (스터디)
          6-3. 제목 + 팀원 (팀빌딩)
+
 */
 
     private final PostService postService;
@@ -39,6 +42,7 @@ public class PostController {
     // 1. 게시글 생성
     @PostMapping("")
     public ResponseEntity<PostDetailResponse> createPost(@RequestBody PostCreateRequest request) {
+        log.info(request.toString());
         PostDetailResponse response = postService.addPost(request);
 
         return ResponseEntity.ok(response);
@@ -69,12 +73,12 @@ public class PostController {
     }
 
     // 5. 게시글 목록조회
-    @GetMapping("common-list/") // page => 페이지 번호, criteria => 정렬 기준 (기본은 작성일자)
-    public ResponseEntity<PostCommonListResponse> getCommonList(@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo,
-                                                                @RequestParam(required = false, defaultValue = "createAt", value = "criteria") String criteria,
-                                                                @RequestParam(required = false, defaultValue = "10", value = "size") int size) {
+    @GetMapping("/notice") // page => 페이지 번호, criteria => 정렬 기준 (기본은 작성일자)
+    public ResponseEntity<?> getNoticeList(@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo,
+                                                                   @RequestParam(required = false, defaultValue = "createAt", value = "criteria") String criteria,
+                                                                   @RequestParam(required = false, defaultValue = "10", value = "size") int size) {
         Pageable pageable = PageRequest.of(pageNo, size, Sort.by(criteria).descending());
-        PostCommonListResponse response = postService.getCommonList(pageable);
+        PostCommonListResponse response = postService.getNoticeList(pageable);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/org/example/yulion/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/yulion/domain/post/controller/PostController.java
@@ -71,7 +71,7 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
-    // 5-1. 게시글 목록조회 (공지사항)
+    // 5-1-1. 게시글 목록조회 (공지사항)
     @GetMapping("/notice") // page => 페이지 번호, criteria => 정렬 기준 (기본은 작성일자)
     public ResponseEntity<?> getNoticeList(@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo,
                                                                    @RequestParam(required = false, defaultValue = "createAt", value = "criteria") String criteria,
@@ -81,4 +81,17 @@ public class PostController {
 
         return ResponseEntity.ok(response);
     }
+
+    // 5-1-2. 게시글 목록조회 (커뮤니티)
+    @GetMapping("/community")
+    public ResponseEntity<?> getCommunityList(@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo,
+                                                                   @RequestParam(required = false, defaultValue = "createAt", value = "criteria") String criteria,
+                                                                   @RequestParam(required = false, defaultValue = "10", value = "size") int size) {
+        Pageable pageable = PageRequest.of(pageNo, size, Sort.by(criteria).descending());
+        PostCommonListResponse response = postService.getCommunityList(pageable);
+
+        return ResponseEntity.ok(response);
+    }
+
+
 }

--- a/src/main/java/org/example/yulion/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/yulion/domain/post/controller/PostController.java
@@ -1,10 +1,12 @@
 package org.example.yulion.domain.post.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
 import org.example.yulion.domain.post.dto.request.PostCreateRequest;
 import org.example.yulion.domain.post.dto.response.PostCommonListResponse;
 import org.example.yulion.domain.post.dto.response.PostCommonSummaryResponse;
 import org.example.yulion.domain.post.dto.response.PostDetailResponse;
+import org.example.yulion.domain.post.dto.response.PostEducationListResponse;
 import org.example.yulion.domain.post.service.PostService;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -23,8 +25,8 @@ public class PostController {
      3. 게시글 수정
      4. 게시글 삭제
      5. 게시글 목록 조회
-         5-1. id + 파트 + 제목 + 작성자 + 작성일 + 조회수 (Notice, 커뮤니티)
-         5-2. id + 파트 + 제목 +  팀원 (스터디, 팀빌딩, Homework)
+         5-1. id + 파트 + 제목 + 작성자 + 작성일 + 조회수 (Notice, 커뮤니티) (Common)
+         5-2. id + 파트 + 제목 +  팀원 (스터디, 팀빌딩, Homework) (Education)
 
      6. 게시글 요약 목록 조회 (세가지)
          6-1. 제목 + 날짜 (Notice, 커뮤니티, Q&A, Homework))
@@ -65,7 +67,7 @@ public class PostController {
 
     // 4. 게시글 삭제
     @DeleteMapping("/{id}")
-    public ResponseEntity<?> deletePost(@PathVariable Long id) {
+    public ResponseEntity<PostDetailResponse> deletePost(@PathVariable Long id) {
         PostDetailResponse response = postService.deletePost(id);
 
         return ResponseEntity.ok(response);
@@ -73,25 +75,48 @@ public class PostController {
 
     // 5-1-1. 게시글 목록조회 (공지사항)
     @GetMapping("/notice") // page => 페이지 번호, criteria => 정렬 기준 (기본은 작성일자)
-    public ResponseEntity<?> getNoticeList(@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo,
-                                                                   @RequestParam(required = false, defaultValue = "createAt", value = "criteria") String criteria,
-                                                                   @RequestParam(required = false, defaultValue = "10", value = "size") int size) {
-        Pageable pageable = PageRequest.of(pageNo, size, Sort.by(criteria).descending());
-        PostCommonListResponse response = postService.getNoticeList(pageable);
+    public ResponseEntity<PostCommonListResponse> getNoticeList(Pageable pageable) {
+        Long cId = 1L;
+        PostCommonListResponse response = postService.getCommonList(pageable, cId);
 
         return ResponseEntity.ok(response);
     }
 
     // 5-1-2. 게시글 목록조회 (커뮤니티)
     @GetMapping("/community")
-    public ResponseEntity<?> getCommunityList(@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo,
-                                                                   @RequestParam(required = false, defaultValue = "createAt", value = "criteria") String criteria,
-                                                                   @RequestParam(required = false, defaultValue = "10", value = "size") int size) {
-        Pageable pageable = PageRequest.of(pageNo, size, Sort.by(criteria).descending());
-        PostCommonListResponse response = postService.getCommunityList(pageable);
+    public ResponseEntity<PostCommonListResponse> getCommunityList(Pageable pageable) {
+        Long cId = 2L;
+        PostCommonListResponse response = postService.getCommonList(pageable, cId);
 
         return ResponseEntity.ok(response);
     }
 
+    // 5-2-1. 게시글 목록조회 (스터디)
+    @GetMapping("/study")
+    public ResponseEntity<PostEducationListResponse> getStudyList(Pageable pageable) {
+        Long cId = 3L;
+        PostEducationListResponse response = postService.getEducationList(pageable, cId);
 
+        return ResponseEntity.ok(response);
+    }
+
+    // 5-2-2. 게시글 목록조회 (팀빌딩)
+    @GetMapping("/team")
+    public ResponseEntity<PostEducationListResponse> getTeamList(Pageable pageable) {
+        Long cId = 4L;
+        PostEducationListResponse response = postService.getEducationList(pageable, cId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    // 5-2-3. 게시글 목록조회 (과제)
+    @GetMapping("/homework")
+    public ResponseEntity<PostCommonListResponse> getHomeworkList(Pageable pageable) {
+        Long cId = 5L;
+        PostCommonListResponse response = postService.getCommonList(pageable, cId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    //
 }

--- a/src/main/java/org/example/yulion/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/yulion/domain/post/controller/PostController.java
@@ -42,7 +42,6 @@ public class PostController {
     // 1. 게시글 생성
     @PostMapping("")
     public ResponseEntity<PostDetailResponse> createPost(@RequestBody PostCreateRequest request) {
-        log.info(request.toString());
         PostDetailResponse response = postService.addPost(request);
 
         return ResponseEntity.ok(response);
@@ -72,7 +71,7 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
-    // 5. 게시글 목록조회
+    // 5-1. 게시글 목록조회 (공지사항)
     @GetMapping("/notice") // page => 페이지 번호, criteria => 정렬 기준 (기본은 작성일자)
     public ResponseEntity<?> getNoticeList(@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo,
                                                                    @RequestParam(required = false, defaultValue = "createAt", value = "criteria") String criteria,

--- a/src/main/java/org/example/yulion/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/yulion/domain/post/controller/PostController.java
@@ -41,7 +41,20 @@ public class PostController {
     }
 
     // 2. 게시글 조회 (상세 조회)
+    @GetMapping("/{id}")
+    public ResponseEntity<PostDetailResponse> getPost(@PathVariable Long id) {
+        PostDetailResponse response = postService.getPost(id);
 
+        return ResponseEntity.ok(response);
+    }
 
+    // 3. 게시글 수정
+    @PutMapping("/{id}")
+    public ResponseEntity<PostDetailResponse> modifyPost(@PathVariable Long id, @RequestBody PostCreateRequest request) {
+        PostDetailResponse response = postService.modifyPost(id, request);
 
+        return ResponseEntity.ok(response);
+    }
+
+    // 4. 게시글 삭제
 }

--- a/src/main/java/org/example/yulion/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/yulion/domain/post/controller/PostController.java
@@ -57,4 +57,14 @@ public class PostController {
     }
 
     // 4. 게시글 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deletePost(@PathVariable Long id) {
+        PostDetailResponse response = postService.deletePost(id);
+
+        return ResponseEntity.ok(response);
+    }
+
+    // 5. 게시글 목록조회
+    @GetMapping("")
+
 }

--- a/src/main/java/org/example/yulion/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/yulion/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package org.example.yulion.domain.post.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.example.yulion.domain.post.dto.request.PostCreateRequest;
 import org.example.yulion.domain.post.dto.response.PostCommonListResponse;
@@ -8,15 +9,18 @@ import org.example.yulion.domain.post.dto.response.PostCommonSummaryResponse;
 import org.example.yulion.domain.post.dto.response.PostDetailResponse;
 import org.example.yulion.domain.post.dto.response.PostEducationListResponse;
 import org.example.yulion.domain.post.service.PostService;
+import org.example.yulion.global.auth.userdetails.CustomUserDetails;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequestMapping("/api/v1/posts")
 @RestController
+@Tag(name = "Post", description = "게시글 관련 API")
 public class PostController {
 /*
      필요한 API
@@ -42,14 +46,17 @@ public class PostController {
     }
 
     // 1. 게시글 생성
+    @Operation(summary = "게시글 생성", description = "category ID는 다음과 같습니다. 1: 공지사항, 2: 커뮤니티, 3: 스터디, 4: 팀빌딩, 5: 과제<br>part ID는 다음과 같습니다. 1:BE, 2:FE, 3:UI/UX, 4:ALL")
     @PostMapping("")
-    public ResponseEntity<PostDetailResponse> createPost(@RequestBody PostCreateRequest request) {
-        PostDetailResponse response = postService.addPost(request);
+    public ResponseEntity<PostDetailResponse> createPost(@RequestBody PostCreateRequest request,
+                                                         @AuthenticationPrincipal CustomUserDetails userDetails) {
+        PostDetailResponse response = postService.addPost(request, userDetails.getId());
 
         return ResponseEntity.ok(response);
     }
 
     // 2. 게시글 조회 (상세 조회)
+    @Operation(summary = "게시글 조회 (상세 조회)")
     @GetMapping("/{id}")
     public ResponseEntity<PostDetailResponse> getPost(@PathVariable Long id) {
         PostDetailResponse response = postService.getPost(id);
@@ -58,22 +65,28 @@ public class PostController {
     }
 
     // 3. 게시글 수정
+    @Operation(summary = "게시글 수정")
     @PutMapping("/{id}")
-    public ResponseEntity<PostDetailResponse> modifyPost(@PathVariable Long id, @RequestBody PostCreateRequest request) {
-        PostDetailResponse response = postService.modifyPost(id, request);
+    public ResponseEntity<PostDetailResponse> modifyPost(@PathVariable Long id,
+                                                         @RequestBody PostCreateRequest request,
+                                                         @AuthenticationPrincipal CustomUserDetails userDetails) {
+        PostDetailResponse response = postService.modifyPost(id, request, userDetails.getId());
 
         return ResponseEntity.ok(response);
     }
 
     // 4. 게시글 삭제
+    @Operation(summary = "게시글 삭제")
     @DeleteMapping("/{id}")
-    public ResponseEntity<PostDetailResponse> deletePost(@PathVariable Long id) {
-        PostDetailResponse response = postService.deletePost(id);
+    public ResponseEntity<PostDetailResponse> deletePost(@PathVariable Long id,
+                                                         @AuthenticationPrincipal CustomUserDetails userDetails) {
+        PostDetailResponse response = postService.deletePost(id, userDetails.getId());
 
         return ResponseEntity.ok(response);
     }
 
     // 5-1-1. 게시글 목록조회 (공지사항)
+    @Operation(summary = "게시글 목록 조회 (공지사항)")
     @GetMapping("/notice") // page => 페이지 번호, criteria => 정렬 기준 (기본은 작성일자)
     public ResponseEntity<PostCommonListResponse> getNoticeList(Pageable pageable) {
         Long cId = 1L;
@@ -83,6 +96,7 @@ public class PostController {
     }
 
     // 5-1-2. 게시글 목록조회 (커뮤니티)
+    @Operation(summary = "게시글 목록 조회 (커뮤니티)")
     @GetMapping("/community")
     public ResponseEntity<PostCommonListResponse> getCommunityList(Pageable pageable) {
         Long cId = 2L;
@@ -92,6 +106,7 @@ public class PostController {
     }
 
     // 5-2-1. 게시글 목록조회 (스터디)
+    @Operation(summary = "게시글 목록 조회 (스터디)")
     @GetMapping("/study")
     public ResponseEntity<PostEducationListResponse> getStudyList(Pageable pageable) {
         Long cId = 3L;
@@ -101,6 +116,7 @@ public class PostController {
     }
 
     // 5-2-2. 게시글 목록조회 (팀빌딩)
+    @Operation(summary = "게시글 목록 조회 (팀빌딩)")
     @GetMapping("/team")
     public ResponseEntity<PostEducationListResponse> getTeamList(Pageable pageable) {
         Long cId = 4L;
@@ -110,6 +126,7 @@ public class PostController {
     }
 
     // 5-2-3. 게시글 목록조회 (과제)
+    @Operation(summary = "게시글 목록 조회 (과제)")
     @GetMapping("/homework")
     public ResponseEntity<PostCommonListResponse> getHomeworkList(Pageable pageable) {
         Long cId = 5L;

--- a/src/main/java/org/example/yulion/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/yulion/domain/post/controller/PostController.java
@@ -1,0 +1,47 @@
+package org.example.yulion.domain.post.controller;
+
+import org.example.yulion.domain.post.domain.Post;
+import org.example.yulion.domain.post.dto.request.PostCreateRequest;
+import org.example.yulion.domain.post.dto.response.PostDetailResponse;
+import org.example.yulion.domain.post.service.PostService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/v1/posts")
+@RestController
+public class PostController {
+/*
+     필요한 API
+     1. 게시글 생성
+     2. 게시글 조회 (상세 조회)
+     3. 게시글 수정
+     4. 게시글 삭제
+     5. 게시글 목록 조회
+         5-1. id + 파트 + 제목 + 작성자 + 작성일 + 조회수 (스터디 제외 전부)
+         5-2. id + 파트 + 제목 + 팀원 (스터디)
+
+     6. 게시글 요약 목록 조회 (세가지)
+         6-1. 제목 + 날짜 (아래 제외 전부)
+         6-2. 제목 + 작성자(멘토) (스터디)
+         6-3. 제목 + 팀원 (팀빌딩)
+*/
+
+    private final PostService postService;
+
+    public PostController(PostService postService) {
+        this.postService = postService;
+    }
+
+    // 1. 게시글 생성
+    @PostMapping("")
+    public ResponseEntity<PostDetailResponse> createPost(@RequestBody PostCreateRequest request) {
+        PostDetailResponse response = postService.addPost(request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    // 2. 게시글 조회 (상세 조회)
+
+
+
+}

--- a/src/main/java/org/example/yulion/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/yulion/domain/post/controller/PostController.java
@@ -2,8 +2,12 @@ package org.example.yulion.domain.post.controller;
 
 import org.example.yulion.domain.post.domain.Post;
 import org.example.yulion.domain.post.dto.request.PostCreateRequest;
+import org.example.yulion.domain.post.dto.response.PostCommonListResponse;
 import org.example.yulion.domain.post.dto.response.PostDetailResponse;
 import org.example.yulion.domain.post.service.PostService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -65,6 +69,13 @@ public class PostController {
     }
 
     // 5. 게시글 목록조회
-    @GetMapping("")
+    @GetMapping("common-list/") // page => 페이지 번호, criteria => 정렬 기준 (기본은 작성일자)
+    public ResponseEntity<PostCommonListResponse> getCommonList(@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo,
+                                                                @RequestParam(required = false, defaultValue = "createAt", value = "criteria") String criteria,
+                                                                @RequestParam(required = false, defaultValue = "10", value = "size") int size) {
+        Pageable pageable = PageRequest.of(pageNo, size, Sort.by(criteria).descending());
+        PostCommonListResponse response = postService.getCommonList(pageable);
 
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/org/example/yulion/domain/post/domain/Post.java
+++ b/src/main/java/org/example/yulion/domain/post/domain/Post.java
@@ -13,6 +13,7 @@ import org.hibernate.annotations.ColumnDefault;
 @Table(name = "post")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
 public class Post extends BaseTimeEntity {
 
     @Id
@@ -42,8 +43,11 @@ public class Post extends BaseTimeEntity {
     @Column(nullable = true)
     private String members;
 
+    @Column(nullable = true)
+    private String mentor;
+
     @Builder
-    private Post (String title, String content, Long viewCnt, String members, User writer, Category category, Part part){
+    private Post (String title, String content, Long viewCnt, String members, User writer, Category category, Part part, String mentor){
         this.title = title;
         this.content = content;
         this.viewCnt = viewCnt;
@@ -51,6 +55,7 @@ public class Post extends BaseTimeEntity {
         this.writer = writer;
         this.category = category;
         this.part = part;
+        this.mentor = mentor;
     }
 
     // 연관관계 매핑 메소드

--- a/src/main/java/org/example/yulion/domain/post/domain/Post.java
+++ b/src/main/java/org/example/yulion/domain/post/domain/Post.java
@@ -52,7 +52,6 @@ public class Post extends BaseTimeEntity {
 //        this.writer = user;
 //        user.getPosts().add(this);
 //    }
-
     public void modifyPost(String title, String content, String members, Category category, Part part){
         this.title = title;
         this.content = content;

--- a/src/main/java/org/example/yulion/domain/post/domain/Post.java
+++ b/src/main/java/org/example/yulion/domain/post/domain/Post.java
@@ -8,9 +8,8 @@ import org.example.yulion.domain.part.domain.Part;
 import org.example.yulion.domain.user.domain.User;
 
 @Entity
-@Table
+@Table(name = "post")
 @Getter
-@ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseTimeEntity {
 
@@ -19,6 +18,7 @@ public class Post extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn (name = "user_id")
     private User writer;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/example/yulion/domain/post/domain/Post.java
+++ b/src/main/java/org/example/yulion/domain/post/domain/Post.java
@@ -53,4 +53,12 @@ public class Post extends BaseTimeEntity {
 //        user.getPosts().add(this);
 //    }
 
+    public void modifyPost(String title, String content, String members, Category category, Part part){
+        this.title = title;
+        this.content = content;
+        this.members = members;
+        this.category = category;
+        this.part = part;
+    }
+
 }

--- a/src/main/java/org/example/yulion/domain/post/domain/Post.java
+++ b/src/main/java/org/example/yulion/domain/post/domain/Post.java
@@ -37,11 +37,20 @@ public class Post extends BaseTimeEntity {
     private String members;
 
     @Builder
-    protected Post (String title, String content, Long viewCnt, String members){
+    protected Post (String title, String content, Long viewCnt, String members, User writer, Category category, Part part){
         this.title = title;
         this.content = content;
         this.viewCnt = viewCnt;
         this.members = members;
+        this.writer = writer;
+        this.category = category;
+        this.part = part;
     }
+
+    // 연관관계 매핑 메소드
+//    public void setWriter(User user){
+//        this.writer = user;
+//        user.getPosts().add(this);
+//    }
 
 }

--- a/src/main/java/org/example/yulion/domain/post/domain/Post.java
+++ b/src/main/java/org/example/yulion/domain/post/domain/Post.java
@@ -1,0 +1,47 @@
+package org.example.yulion.domain.post.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.yulion.domain.category.domain.Category;
+import org.example.yulion.domain.common.BaseTimeEntity;
+import org.example.yulion.domain.part.domain.Part;
+import org.example.yulion.domain.user.domain.User;
+
+@Entity
+@Table
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User writer;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Category category;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Part part;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String content;
+    private Long viewCnt;
+
+    @Column(nullable = true)
+    private String members;
+
+    @Builder
+    protected Post (String title, String content, Long viewCnt, String members){
+        this.title = title;
+        this.content = content;
+        this.viewCnt = viewCnt;
+        this.members = members;
+    }
+
+}

--- a/src/main/java/org/example/yulion/domain/post/domain/Post.java
+++ b/src/main/java/org/example/yulion/domain/post/domain/Post.java
@@ -1,16 +1,17 @@
 package org.example.yulion.domain.post.domain;
 
+import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.*;
 import org.example.yulion.domain.category.domain.Category;
 import org.example.yulion.domain.common.BaseTimeEntity;
 import org.example.yulion.domain.part.domain.Part;
 import org.example.yulion.domain.user.domain.User;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
-@Table
+@Table(name = "post")
 @Getter
-@ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseTimeEntity {
 
@@ -19,25 +20,30 @@ public class Post extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn (name = "user_id")
     private User writer;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn (name = "category_id")
     private Category category;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn (name = "part_id")
     private Part part;
 
     @Column(nullable = false)
     private String title;
 
     private String content;
+
+    @ColumnDefault("0")
     private Long viewCnt;
 
     @Column(nullable = true)
     private String members;
 
     @Builder
-    protected Post (String title, String content, Long viewCnt, String members, User writer, Category category, Part part){
+    private Post (String title, String content, Long viewCnt, String members, User writer, Category category, Part part){
         this.title = title;
         this.content = content;
         this.viewCnt = viewCnt;

--- a/src/main/java/org/example/yulion/domain/post/domain/Post.java
+++ b/src/main/java/org/example/yulion/domain/post/domain/Post.java
@@ -9,6 +9,8 @@ import org.example.yulion.domain.part.domain.Part;
 import org.example.yulion.domain.user.domain.User;
 import org.hibernate.annotations.ColumnDefault;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "post")
 @Getter
@@ -46,6 +48,13 @@ public class Post extends BaseTimeEntity {
     @Column(nullable = true)
     private String mentor;
 
+    @Enumerated(EnumType.STRING)
+
+    @ColumnDefault("'ACTIVE'")
+    private PostStatus status;
+
+    private LocalDateTime deletedAt;
+
     @Builder
     private Post (String title, String content, Long viewCnt, String members, User writer, Category category, Part part, String mentor){
         this.title = title;
@@ -69,6 +78,11 @@ public class Post extends BaseTimeEntity {
         this.members = members;
         this.category = category;
         this.part = part;
+    }
+
+    public void deletePost(){
+        this.status = PostStatus.DELETED;
+        this.deletedAt = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/org/example/yulion/domain/post/domain/PostStatus.java
+++ b/src/main/java/org/example/yulion/domain/post/domain/PostStatus.java
@@ -1,0 +1,15 @@
+package org.example.yulion.domain.post.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum PostStatus {
+
+    ACTIVE("게시 중"),
+    DELETED("삭제 됨"),
+    ;
+    private final String title;
+}

--- a/src/main/java/org/example/yulion/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/example/yulion/domain/post/dto/request/PostCreateRequest.java
@@ -1,5 +1,6 @@
 package org.example.yulion.domain.post.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @NoArgsConstructor
 @Getter
+@Schema(description = "게시글 생성 요청")
 public class PostCreateRequest {
     @NotBlank
     private String title;

--- a/src/main/java/org/example/yulion/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/example/yulion/domain/post/dto/request/PostCreateRequest.java
@@ -1,0 +1,25 @@
+package org.example.yulion.domain.post.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PostCreateRequest {
+    @NotBlank
+    private String title;
+
+    private String content;
+    private String members;
+    private String category;
+    private String part;
+
+    @Builder
+    public PostCreateRequest(String title, String content, String members, String category, String part) {
+        this.title = title;
+        this.content = content;
+        this.members = members;
+        this.category = category;
+        this.part = part;
+    }
+}

--- a/src/main/java/org/example/yulion/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/example/yulion/domain/post/dto/request/PostCreateRequest.java
@@ -3,8 +3,10 @@ package org.example.yulion.domain.post.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+@NoArgsConstructor
 @Getter
 public class PostCreateRequest {
     @NotBlank

--- a/src/main/java/org/example/yulion/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/example/yulion/domain/post/dto/request/PostCreateRequest.java
@@ -3,6 +3,7 @@ package org.example.yulion.domain.post.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 @Getter
 public class PostCreateRequest {
@@ -16,6 +17,7 @@ public class PostCreateRequest {
 
     @Builder
     public PostCreateRequest(String title, String content, String members, String category, String part) {
+
         this.title = title;
         this.content = content;
         this.members = members;

--- a/src/main/java/org/example/yulion/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/example/yulion/domain/post/dto/request/PostCreateRequest.java
@@ -3,8 +3,10 @@ package org.example.yulion.domain.post.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+@NoArgsConstructor
 @Getter
 public class PostCreateRequest {
     @NotBlank
@@ -12,12 +14,11 @@ public class PostCreateRequest {
 
     private String content;
     private String members;
-    private String category;
-    private String part;
+    private Long category;
+    private Long part;
 
     @Builder
-    public PostCreateRequest(String title, String content, String members, String category, String part) {
-
+    public PostCreateRequest(String title, String content, String members, Long category, Long part) {
         this.title = title;
         this.content = content;
         this.members = members;

--- a/src/main/java/org/example/yulion/domain/post/dto/response/PostCommonListResponse.java
+++ b/src/main/java/org/example/yulion/domain/post/dto/response/PostCommonListResponse.java
@@ -1,7 +1,10 @@
 package org.example.yulion.domain.post.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "게시글 목록 조회 (공지사항, 커뮤니티)")
 public record PostCommonListResponse(
         List<PostCommonSummaryResponse> content,
         int currentPage,

--- a/src/main/java/org/example/yulion/domain/post/dto/response/PostCommonListResponse.java
+++ b/src/main/java/org/example/yulion/domain/post/dto/response/PostCommonListResponse.java
@@ -1,26 +1,16 @@
 package org.example.yulion.domain.post.dto.response;
 
-import org.example.yulion.domain.post.domain.Post;
-import org.example.yulion.domain.user.domain.User;
-
-import java.time.LocalDateTime;
+import java.util.List;
 
 public record PostCommonListResponse(
-    Long id,
-    String part,
-    String title,
-    User writer,
-    LocalDateTime createAt,
-    Long viewCnt) {
-
-    public static PostCommonListResponse from(Post post) {
-        return new PostCommonListResponse(
-            post.getId(),
-            post.getPart().getName(),
-            post.getTitle(),
-            post.getWriter(),
-            post.getCreateAt(),
-            post.getViewCnt()
-        );
+        List<PostCommonSummaryResponse> content,
+        int currentPage,
+        int totalPage
+) {
+    public static PostCommonListResponse from(
+            List<PostCommonSummaryResponse> content,
+            int currentPage,
+            int totalPage) {
+        return new PostCommonListResponse(content, currentPage, totalPage);
     }
 }

--- a/src/main/java/org/example/yulion/domain/post/dto/response/PostCommonListResponse.java
+++ b/src/main/java/org/example/yulion/domain/post/dto/response/PostCommonListResponse.java
@@ -1,0 +1,26 @@
+package org.example.yulion.domain.post.dto.response;
+
+import org.example.yulion.domain.post.domain.Post;
+import org.example.yulion.domain.user.domain.User;
+
+import java.time.LocalDateTime;
+
+public record PostCommonListResponse(
+    Long id,
+    String part,
+    String title,
+    User writer,
+    LocalDateTime createAt,
+    Long viewCnt) {
+
+    public static PostCommonListResponse from(Post post) {
+        return new PostCommonListResponse(
+            post.getId(),
+            post.getPart().getName(),
+            post.getTitle(),
+            post.getWriter(),
+            post.getCreateAt(),
+            post.getViewCnt()
+        );
+    }
+}

--- a/src/main/java/org/example/yulion/domain/post/dto/response/PostCommonSummaryResponse.java
+++ b/src/main/java/org/example/yulion/domain/post/dto/response/PostCommonSummaryResponse.java
@@ -9,7 +9,7 @@ public record PostCommonSummaryResponse(
     Long id,
     String part,
     String title,
-    User writer,
+    String writer,
     LocalDateTime createAt,
     Long viewCnt) {
 
@@ -18,7 +18,7 @@ public record PostCommonSummaryResponse(
             post.getId(),
             post.getPart().getName(),
             post.getTitle(),
-            post.getWriter(),
+            post.getWriter().getNickname(),
             post.getCreateAt(),
             post.getViewCnt()
         );

--- a/src/main/java/org/example/yulion/domain/post/dto/response/PostCommonSummaryResponse.java
+++ b/src/main/java/org/example/yulion/domain/post/dto/response/PostCommonSummaryResponse.java
@@ -1,7 +1,13 @@
 package org.example.yulion.domain.post.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.example.yulion.domain.post.domain.Post;
 import org.example.yulion.domain.user.domain.User;
+
+import static org.example.yulion.global.utils.ProjectTimeFormat.LOCAL_DATE_TIME_PATTERN;
+import static org.example.yulion.global.utils.ProjectTimeFormat.LOCAL_DATE_TIME_PATTERN_EXAMPLE;
+
 
 import java.time.LocalDateTime;
 
@@ -10,6 +16,8 @@ public record PostCommonSummaryResponse(
     String part,
     String title,
     String writer,
+    @Schema(description = "작성일", example = LOCAL_DATE_TIME_PATTERN_EXAMPLE)
+    @JsonFormat(pattern = LOCAL_DATE_TIME_PATTERN)
     LocalDateTime createAt,
     Long viewCnt) {
 

--- a/src/main/java/org/example/yulion/domain/post/dto/response/PostCommonSummaryResponse.java
+++ b/src/main/java/org/example/yulion/domain/post/dto/response/PostCommonSummaryResponse.java
@@ -1,0 +1,26 @@
+package org.example.yulion.domain.post.dto.response;
+
+import org.example.yulion.domain.post.domain.Post;
+import org.example.yulion.domain.user.domain.User;
+
+import java.time.LocalDateTime;
+
+public record PostCommonSummaryResponse(
+    Long id,
+    String part,
+    String title,
+    User writer,
+    LocalDateTime createAt,
+    Long viewCnt) {
+
+    public static PostCommonSummaryResponse from(Post post) {
+        return new PostCommonSummaryResponse(
+            post.getId(),
+            post.getPart().getName(),
+            post.getTitle(),
+            post.getWriter(),
+            post.getCreateAt(),
+            post.getViewCnt()
+        );
+    }
+}

--- a/src/main/java/org/example/yulion/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/org/example/yulion/domain/post/dto/response/PostDetailResponse.java
@@ -1,0 +1,25 @@
+package org.example.yulion.domain.post.dto.response;
+
+import org.example.yulion.domain.post.domain.Post;
+
+public record PostDetailResponse (
+        Long id,
+        Long userId,
+        String part,
+        String category,
+        String title,
+        String content,
+        String members) {
+    public static PostDetailResponse from(final Post post) {
+        return new PostDetailResponse(
+                post.getId(),
+                post.getWriter().getId(),
+                post.getPart().getName(),
+                post.getCategory().getName(),
+                post.getTitle(),
+                post.getContent(),
+                post.getMembers()
+        );
+
+    }
+}

--- a/src/main/java/org/example/yulion/domain/post/dto/response/PostEducationListResponse.java
+++ b/src/main/java/org/example/yulion/domain/post/dto/response/PostEducationListResponse.java
@@ -1,0 +1,16 @@
+package org.example.yulion.domain.post.dto.response;
+
+import java.util.List;
+
+public record PostEducationListResponse(
+        List<PostEducationSummaryResponse> content,
+        int currentPage,
+        int totalPage
+) {
+    public static PostEducationListResponse from(
+            List<PostEducationSummaryResponse> content,
+            int currentPage,
+            int totalPage) {
+        return new PostEducationListResponse(content, currentPage, totalPage);
+    }
+}

--- a/src/main/java/org/example/yulion/domain/post/dto/response/PostEducationListResponse.java
+++ b/src/main/java/org/example/yulion/domain/post/dto/response/PostEducationListResponse.java
@@ -1,7 +1,10 @@
 package org.example.yulion.domain.post.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "게시글 목록 조회 (스터디, 팀빌딩, 과제)")
 public record PostEducationListResponse(
         List<PostEducationSummaryResponse> content,
         int currentPage,

--- a/src/main/java/org/example/yulion/domain/post/dto/response/PostEducationSummaryResponse.java
+++ b/src/main/java/org/example/yulion/domain/post/dto/response/PostEducationSummaryResponse.java
@@ -1,0 +1,23 @@
+package org.example.yulion.domain.post.dto.response;
+
+import org.example.yulion.domain.post.domain.Post;
+
+import java.time.LocalDateTime;
+
+public record PostEducationSummaryResponse(
+        Long id,
+        String part,
+        String title,
+        String members,
+        String mentor) {
+
+    public static PostEducationSummaryResponse from(Post post) {
+        return new PostEducationSummaryResponse(
+                post.getId(),
+                post.getPart().getName(),
+                post.getTitle(),
+                post.getMembers(),
+                post.getMentor()
+        );
+    }
+}

--- a/src/main/java/org/example/yulion/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/example/yulion/domain/post/repository/PostRepository.java
@@ -1,0 +1,9 @@
+package org.example.yulion.domain.post.repository;
+
+import org.example.yulion.domain.post.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long>{
+}

--- a/src/main/java/org/example/yulion/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/example/yulion/domain/post/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package org.example.yulion.domain.post.repository;
 
+import org.example.yulion.domain.category.domain.Category;
 import org.example.yulion.domain.post.domain.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -8,5 +9,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long>{
-    Page<Post> findAllCommon(Pageable pageable);
+    Page<Post> findAllByCategoryOrderByCreateAt(Category category, Pageable pageable);
 }

--- a/src/main/java/org/example/yulion/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/example/yulion/domain/post/repository/PostRepository.java
@@ -1,9 +1,12 @@
 package org.example.yulion.domain.post.repository;
 
 import org.example.yulion.domain.post.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long>{
+    Page<Post> findAllCommon(Pageable pageable);
 }

--- a/src/main/java/org/example/yulion/domain/post/service/PostService.java
+++ b/src/main/java/org/example/yulion/domain/post/service/PostService.java
@@ -39,10 +39,7 @@ public class PostService {
                 .orElseThrow(() -> new IllegalArgumentException("잘못된 유저"));
 
         Post post = createPost(request, user);
-        // log.info(post.getId().toString());
         Post savedPost = postRepository.save(post);
-
-        log.info("savedPost : {}", savedPost);
 
         return PostDetailResponse.from(savedPost);
     }

--- a/src/main/java/org/example/yulion/domain/post/service/PostService.java
+++ b/src/main/java/org/example/yulion/domain/post/service/PostService.java
@@ -2,6 +2,7 @@ package org.example.yulion.domain.post.service;
 
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
+
 import lombok.extern.slf4j.Slf4j;
 import org.example.yulion.domain.category.domain.Category;
 import org.example.yulion.domain.category.repository.CategoryRepository;
@@ -39,7 +40,10 @@ public class PostService {
         User user = userRepository.findById(1L)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저 없음"));
         Post post = createPost(request, user);
+        // log.info(post.getId().toString());
         Post savedPost = postRepository.save(post);
+
+        log.info("savedPost : {}", savedPost);
 
         return PostDetailResponse.from(savedPost);
     }

--- a/src/main/java/org/example/yulion/domain/post/service/PostService.java
+++ b/src/main/java/org/example/yulion/domain/post/service/PostService.java
@@ -2,6 +2,7 @@ package org.example.yulion.domain.post.service;
 
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
+
 import lombok.extern.slf4j.Slf4j;
 import org.example.yulion.domain.category.domain.Category;
 import org.example.yulion.domain.category.repository.CategoryRepository;
@@ -38,25 +39,28 @@ public class PostService {
         // 인증 구현전 테스팅용 유저 정보 가져오기
         User user = userRepository.findById(1L)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저 없음"));
+
         Post post = createPost(request, user);
         Post savedPost = postRepository.save(post);
+
+        log.info("savedPost : {}", savedPost);
 
         return PostDetailResponse.from(savedPost);
     }
 
     public Post createPost(final PostCreateRequest request, final User user) {
-        Category category = categoryRepository.findByName(request.getCategory())
+        Category category = categoryRepository.findById(request.getCategory())
                 .orElseThrow(() -> new IllegalArgumentException("해당 카테고리 없음"));
-        Part part = partRepository.findByName(request.getPart())
+        Part part = partRepository.findById(request.getPart())
                 .orElseThrow(() -> new IllegalArgumentException("해당 파트 없음"));
 
         return Post.builder()
                 .title(request.getTitle())
                 .content(request.getContent())
                 .members(request.getMembers())
+                .part(part)
                 .category(category)
                 .writer(user)
-                .part(part)
                 .build();
     }
 
@@ -70,9 +74,9 @@ public class PostService {
     public PostDetailResponse modifyPost(Long id, PostCreateRequest request) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글 없음"));
-        Category category = categoryRepository.findByName(request.getCategory())
+        Category category = categoryRepository.findById(request.getCategory())
                 .orElseThrow(() -> new IllegalArgumentException("해당 카테고리 없음"));
-        Part part = partRepository.findByName(request.getPart())
+        Part part = partRepository.findById(request.getPart())
                 .orElseThrow(() -> new IllegalArgumentException("해당 파트 없음"));
 
         post.modifyPost(request.getTitle(), request.getContent(), request.getMembers(), category, part);

--- a/src/main/java/org/example/yulion/domain/post/service/PostService.java
+++ b/src/main/java/org/example/yulion/domain/post/service/PostService.java
@@ -9,10 +9,15 @@ import org.example.yulion.domain.part.domain.Part;
 import org.example.yulion.domain.part.repository.PartRepository;
 import org.example.yulion.domain.post.domain.Post;
 import org.example.yulion.domain.post.dto.request.PostCreateRequest;
+import org.example.yulion.domain.post.dto.response.PostCommonListResponse;
 import org.example.yulion.domain.post.dto.response.PostDetailResponse;
 import org.example.yulion.domain.post.repository.PostRepository;
 import org.example.yulion.domain.user.domain.User;
 import org.example.yulion.domain.user.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -79,5 +84,12 @@ public class PostService {
         postRepository.delete(post);
 
         return PostDetailResponse.from(post);
+    }
+
+    public PostCommonListResponse getCommonList(Pageable pageable){
+
+        Page<Post> page = postRepository.findAllCommon(pageable);
+
+        // return PostCommonLinstResponse.from(page);
     }
 }

--- a/src/main/java/org/example/yulion/domain/post/service/PostService.java
+++ b/src/main/java/org/example/yulion/domain/post/service/PostService.java
@@ -10,9 +10,7 @@ import org.example.yulion.domain.part.domain.Part;
 import org.example.yulion.domain.part.repository.PartRepository;
 import org.example.yulion.domain.post.domain.Post;
 import org.example.yulion.domain.post.dto.request.PostCreateRequest;
-import org.example.yulion.domain.post.dto.response.PostCommonListResponse;
-import org.example.yulion.domain.post.dto.response.PostCommonSummaryResponse;
-import org.example.yulion.domain.post.dto.response.PostDetailResponse;
+import org.example.yulion.domain.post.dto.response.*;
 import org.example.yulion.domain.post.repository.PostRepository;
 import org.example.yulion.domain.user.domain.User;
 import org.example.yulion.domain.user.repository.UserRepository;
@@ -94,8 +92,9 @@ public class PostService {
         return PostDetailResponse.from(post);
     }
 
-    public PostCommonListResponse getNoticeList(Pageable pageable){
-        Category category = categoryRepository.findById(1L)
+    @Transactional
+    public PostCommonListResponse getCommonList(Pageable pageable, Long categoryId){
+        Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 카테고리 없음"));
         Page<Post> posts = postRepository.findAllByCategoryOrderByCreateAt(category, pageable);
 
@@ -106,15 +105,16 @@ public class PostService {
         return PostCommonListResponse.from(postResponses, posts.getNumber(), posts.getTotalPages());
     }
 
-    public PostCommonListResponse getCommunityList(Pageable pageable){
-        Category category = categoryRepository.findById(2L)
+    @Transactional
+    public PostEducationListResponse getEducationList(Pageable pageable, Long categoryId){
+        Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 카테고리 없음"));
         Page<Post> posts = postRepository.findAllByCategoryOrderByCreateAt(category, pageable);
 
-        List<PostCommonSummaryResponse> postResponses = posts.getContent().stream()
-                .map(PostCommonSummaryResponse::from)
+        List<PostEducationSummaryResponse> postResponses = posts.getContent().stream()
+                .map(PostEducationSummaryResponse::from)
                 .collect(Collectors.toList());
 
-        return PostCommonListResponse.from(postResponses, posts.getNumber(), posts.getTotalPages());
+        return PostEducationListResponse.from(postResponses, posts.getNumber(), posts.getTotalPages());
     }
 }

--- a/src/main/java/org/example/yulion/domain/post/service/PostService.java
+++ b/src/main/java/org/example/yulion/domain/post/service/PostService.java
@@ -1,0 +1,55 @@
+package org.example.yulion.domain.post.service;
+
+import io.swagger.v3.oas.annotations.servers.Server;
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+import org.example.yulion.domain.category.domain.Category;
+import org.example.yulion.domain.category.repository.CategoryRepository;
+import org.example.yulion.domain.part.domain.Part;
+import org.example.yulion.domain.part.repository.PartRepository;
+import org.example.yulion.domain.post.domain.Post;
+import org.example.yulion.domain.post.dto.request.PostCreateRequest;
+import org.example.yulion.domain.post.dto.response.PostDetailResponse;
+import org.example.yulion.domain.post.repository.PostRepository;
+import org.example.yulion.domain.user.domain.User;
+import org.example.yulion.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Transactional
+@Service
+@AllArgsConstructor
+public class PostService {
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final CategoryRepository categoryRepository;
+    private final PartRepository partRepository;
+
+    // 1. Controller => createPost 메서드에 매핑되는 Service 로직
+    public PostDetailResponse addPost(PostCreateRequest request) {
+        User user = userRepository.findById(1L)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저 없음"));
+        Post post = createPost(request, user);
+        Post savedPost = postRepository.save(post);
+
+        return PostDetailResponse.from(savedPost);
+    }
+
+    public Post createPost(final PostCreateRequest request, final User user) {
+        Category category = categoryRepository.findByName(request.getCategory())
+                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리 없음"));
+        Part part = partRepository.findByName(request.getPart())
+                .orElseThrow(() -> new IllegalArgumentException("해당 파트 없음"));
+
+        return Post.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .members(request.getMembers())
+                .category(category)
+                .writer(user)
+                .part(part)
+                .build();
+    }
+
+}

--- a/src/main/java/org/example/yulion/domain/post/service/PostService.java
+++ b/src/main/java/org/example/yulion/domain/post/service/PostService.java
@@ -33,10 +33,10 @@ public class PostService {
     private final PartRepository partRepository;
 
     // 1. Controller => createPost 메서드에 매핑되는 Service 로직
-    public PostDetailResponse addPost(PostCreateRequest request) {
+    public PostDetailResponse addPost(PostCreateRequest request, Long userId) {
         // 인증 구현전 테스팅용 유저 정보 가져오기
-        User user = userRepository.findById(1L)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저 없음"));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 유저"));
 
         Post post = createPost(request, user);
         // log.info(post.getId().toString());
@@ -70,7 +70,7 @@ public class PostService {
         return PostDetailResponse.from(post);
     }
 
-    public PostDetailResponse modifyPost(Long id, PostCreateRequest request) {
+    public PostDetailResponse modifyPost(Long id, PostCreateRequest request, Long userId) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글 없음"));
         Category category = categoryRepository.findById(request.getCategory())
@@ -78,16 +78,24 @@ public class PostService {
         Part part = partRepository.findById(request.getPart())
                 .orElseThrow(() -> new IllegalArgumentException("해당 파트 없음"));
 
+        if (!post.getWriter().getId().equals(userId)) {
+            throw new IllegalArgumentException("작성자만 수정 가능합니다.");
+        }
+
         post.modifyPost(request.getTitle(), request.getContent(), request.getMembers(), category, part);
         final Post savedPost = postRepository.save(post);
 
         return PostDetailResponse.from(savedPost);
     }
 
-    public PostDetailResponse deletePost(Long id) {
+    public PostDetailResponse deletePost(Long id, Long userId) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글 없음"));
         postRepository.delete(post);
+
+        if (!post.getWriter().getId().equals(userId)) {
+            throw new IllegalArgumentException("작성자만 수정 가능합니다.");
+        }
 
         return PostDetailResponse.from(post);
     }

--- a/src/main/java/org/example/yulion/domain/post/service/PostService.java
+++ b/src/main/java/org/example/yulion/domain/post/service/PostService.java
@@ -52,4 +52,25 @@ public class PostService {
                 .build();
     }
 
+    public PostDetailResponse getPost(Long id) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글 없음"));
+
+        return PostDetailResponse.from(post);
+    }
+
+    public PostDetailResponse modifyPost(Long id, PostCreateRequest request) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글 없음"));
+        Category category = categoryRepository.findByName(request.getCategory())
+                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리 없음"));
+        Part part = partRepository.findByName(request.getPart())
+                .orElseThrow(() -> new IllegalArgumentException("해당 파트 없음"));
+
+        post.modifyPost(request.getTitle(), request.getContent(), request.getMembers(), category, part);
+        final Post savedPost = postRepository.save(post);
+
+        return PostDetailResponse.from(savedPost);
+    }
+
 }

--- a/src/main/java/org/example/yulion/domain/post/service/PostService.java
+++ b/src/main/java/org/example/yulion/domain/post/service/PostService.java
@@ -73,4 +73,11 @@ public class PostService {
         return PostDetailResponse.from(savedPost);
     }
 
+    public PostDetailResponse deletePost(Long id) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글 없음"));
+        postRepository.delete(post);
+
+        return PostDetailResponse.from(post);
+    }
 }

--- a/src/main/java/org/example/yulion/domain/post/service/PostService.java
+++ b/src/main/java/org/example/yulion/domain/post/service/PostService.java
@@ -94,7 +94,19 @@ public class PostService {
     }
 
     public PostCommonListResponse getNoticeList(Pageable pageable){
-        Category category = categoryRepository.findByName("Notice")
+        Category category = categoryRepository.findById(1L)
+                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리 없음"));
+        Page<Post> posts = postRepository.findAllByCategoryOrderByCreateAt(category, pageable);
+
+        List<PostCommonSummaryResponse> postResponses = posts.getContent().stream()
+                .map(PostCommonSummaryResponse::from)
+                .collect(Collectors.toList());
+
+        return PostCommonListResponse.from(postResponses, posts.getNumber(), posts.getTotalPages());
+    }
+
+    public PostCommonListResponse getCommunityList(Pageable pageable){
+        Category category = categoryRepository.findById(2L)
                 .orElseThrow(() -> new IllegalArgumentException("해당 카테고리 없음"));
         Page<Post> posts = postRepository.findAllByCategoryOrderByCreateAt(category, pageable);
 

--- a/src/main/java/org/example/yulion/domain/user/domain/User.java
+++ b/src/main/java/org/example/yulion/domain/user/domain/User.java
@@ -3,8 +3,11 @@ package org.example.yulion.domain.user.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.example.yulion.domain.common.BaseTimeEntity;
+import org.example.yulion.domain.post.domain.Post;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -34,6 +37,9 @@ public class User extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private UserStatus status;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Post> posts = new ArrayList<>();
 
     @Builder
     protected User(String password, String phoneNumber, String nickname, String email, UserRole role, String gender, LocalDate birth) {

--- a/src/main/java/org/example/yulion/domain/user/domain/User.java
+++ b/src/main/java/org/example/yulion/domain/user/domain/User.java
@@ -38,7 +38,7 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private UserStatus status;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "writer", cascade = CascadeType.ALL)
     private List<Post> posts = new ArrayList<>();
 
     @Builder

--- a/src/main/java/org/example/yulion/domain/user/domain/User.java
+++ b/src/main/java/org/example/yulion/domain/user/domain/User.java
@@ -38,8 +38,8 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private UserStatus status;
 
-    @OneToMany(mappedBy = "writer", cascade = CascadeType.ALL)
-    private List<Post> posts = new ArrayList<>();
+//    @OneToMany(mappedBy = "writer", cascade = CascadeType.ALL)
+//    private List<Post> posts = new ArrayList<>();
 
     @Builder
     protected User(String password, String phoneNumber, String nickname, String email, UserRole role, String gender, LocalDate birth) {

--- a/src/main/java/org/example/yulion/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/example/yulion/global/config/security/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
             // API
             "/api/v1/auth/**",
             "/api/v1/test/**",
+            "/api/v1/posts/**",
 
             // Swagger
             "/v3/api-docs/**",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,6 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
-      url: jdbc:redis://${REDIS_USER}:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}
       password: ${REDIS_PASSWORD}
 
 app:


### PR DESCRIPTION
## 이슈 연결

- #3 

## 구현한 API

- GET [/api/v1/posts/{id}]  게시글 조회 (상세조회)
- PUT [/api/v1/posts/{id}] 게시글 수정
- DELETE [/api/v1/posts/{id}] 게시글 삭제
- POST [/api/v1/posts] 게시글 생성
- GET [/api/v1/posts/team] 게시글 목록 조회 (팀빌딩)
- GET [/api/v1/posts/study] 게시글 목록 조회 (스터디)
- GET [/api/v1/posts/notice] 게시글 목록 조회 (공지사항)
- GET [/api/v1/posts/homework] 게시글 목록 조회 (과제)
- GET [/api/v1/posts/Community] 게시글 목록 조회 (커뮤니티)

## 작업 사항

- 게시물 관련 API 구현

